### PR TITLE
Feat/add multiply queries and config handlers

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: "postgres:18-alpine"
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
       - ./scripts/create_dev_database.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
     networks:
       - postgres-net

--- a/server/scripts/create_dev_database.sql
+++ b/server/scripts/create_dev_database.sql
@@ -86,6 +86,19 @@ CREATE TABLE IF NOT EXISTS events (
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS agent_configs ( 
+    id BIGSERIAL PRIMARY KEY,
+
+    locations JSON,
+    event_types JSON,
+    sources JSON,
+    honorary_participants JSON,
+    custom_queries JSON,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
 -- Индексы для таблицы events
 CREATE INDEX IF NOT EXISTS idx_events_date_start ON events(date_start);
 CREATE INDEX IF NOT EXISTS idx_events_category ON events(category_id);

--- a/server/server/api/agent.py
+++ b/server/server/api/agent.py
@@ -1,21 +1,14 @@
 import typing
-import smtplib
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
 
 import litestar
-from litestar import status_codes
-from sqlalchemy import orm
 
-from server import models, repositories, schemas
-
-
-# Локальное хранилище конфигурации агента
-_agent_config: schemas.AgentConfigBase | None = None
+from server import repositories, schemas
 
 
 @litestar.get('/agent/config')
-async def get_agent_config() -> schemas.AgentConfigBase | None:
+async def get_agent_config(
+    agent_config_service: repositories.AgentConfigService,
+) -> schemas.AgentConfig | None:
     """Получить текущую конфигурацию агента.
     
     Если конфигурация не существует, возвращается None.
@@ -23,15 +16,22 @@ async def get_agent_config() -> schemas.AgentConfigBase | None:
     Returns:
         Конфигурация агента или None
     """
-    return _agent_config
+    configs = await agent_config_service.list(auto_expunge=True)
+    
+    if not configs:
+        return None
+    
+    return schemas.AgentConfig.model_validate(configs[0])
 
 @litestar.post('/agent/config')
 async def save_agent_config(
+    agent_config_service: repositories.AgentConfigService,
     data: schemas.AgentConfigBase,
-) -> schemas.AgentConfigBase:
+) -> schemas.AgentConfig:
     """Сохранить конфигурацию агента.
     
-    Конфигурация сохраняется локально в памяти.
+    Если конфигурация не существует, создается новая.
+    Если существует, обновляется текущая.
 
     Args:
         data: Полная конфигурация агента
@@ -39,9 +39,26 @@ async def save_agent_config(
     Returns:
         Сохраненная конфигурация агента
     """
-    global _agent_config
-    _agent_config = data
-    return _agent_config
+    configs = await agent_config_service.list(auto_expunge=True)
+
+    config_data = data.model_dump()
+
+    if not configs:
+        config = await agent_config_service.create(
+            config_data,
+            auto_commit=True,
+            auto_expunge=True,
+        )
+    else:
+        config = await agent_config_service.update(
+            item_id=configs[0].id,
+            data=config_data,
+            auto_commit=True,
+            auto_expunge=True,
+        )
+    
+    return schemas.AgentConfig.model_validate(config)
+
 
 
 ROUTER: typing.Final = litestar.Router(

--- a/server/server/api/events.py
+++ b/server/server/api/events.py
@@ -65,7 +65,7 @@ async def search_events(
 
     if price_max is not None:
         filters.append(models.Event.price <= price_max)
-    print(filters)
+
     objects = await events_service.list(
         *filters,
         auto_expunge=True,

--- a/server/server/api/events.py
+++ b/server/server/api/events.py
@@ -2,6 +2,7 @@ import typing
 from datetime import datetime
 
 import litestar
+from litestar.params import Parameter
 from sqlalchemy import and_, orm
 
 from server import models, repositories, schemas
@@ -9,11 +10,11 @@ from server import models, repositories, schemas
 
 @litestar.get('/search')
 async def search_events(
-    events_service: repositories.EventsService,
-    category: str | None = None,
-    region: str | None = None,
-    format: str | None = None,
-    event_type: str | None = None,
+    events_service: repositories.EventsService, 
+    category: typing.List[str] = Parameter(required=False, default=()),
+    region: typing.List[str] = Parameter(required=False, default=()),
+    format: typing.List[str] = Parameter(required=False, default=()),
+    event_type: typing.List[str] = Parameter(required=False, default=()),
     name: str | None = None,
     date_start: datetime | None = None,
     date_end: datetime | None = None,
@@ -38,17 +39,17 @@ async def search_events(
     """
     filters = []
 
-    if category is not None:
-        filters.append(models.Event.category.has(models.Category.name == category))
+    if len(category) != 0 :
+        filters.append(models.Event.category.has(models.Category.name.in_(category)))
 
-    if region is not None:
-        filters.append(models.Event.region.has(models.Region.name == region))
+    if len(region) != 0:
+        filters.append(models.Event.region.has(models.Region.name.in_(region)))
 
-    if format is not None:
-        filters.append(models.Event.format.has(models.Format.name == format))
+    if len(format) != 0:
+        filters.append(models.Event.format.has(models.Format.name.in_(format)))
 
-    if event_type is not None:
-        filters.append(models.Event.event_type.has(models.EventType.name == event_type))
+    if len(event_type) != 0:
+        filters.append(models.Event.event_type.has(models.EventType.name.in_(event_type)))
 
     if name is not None:
         filters.append(models.Event.name.ilike(f'%{name}%'))
@@ -64,7 +65,7 @@ async def search_events(
 
     if price_max is not None:
         filters.append(models.Event.price <= price_max)
-
+    print(filters)
     objects = await events_service.list(
         *filters,
         auto_expunge=True,


### PR DESCRIPTION
fix(postgresql): adjust volume mount path to /var/lib/postgresql

- Changed volume mount path: `/var/lib/postgresql/data` → `/var/lib/postgresql`
- Now uses the official PostgreSQL path (important for versions 18+)
- Fixed issue with creating volumes with random names

feat(search): changing the search logic in the db and changing the handler

- Search parameters (format, region, category, event_type) are now correctly displayed in OpenAPI as an array of strings
- Redesigned filtering logic for fields: format, region, category, event_type

feat(config-handler): implement config handlers logic

- Migrated configuration handler logic from the old repository
- Source branch: feat/stub-email
