### PR TITLE
fix(agent-config): update agent_conf field type in schema

### DIFF
--- a/server/server/schemas.py
+++ b/server/server/schemas.py
@@ -108,7 +108,7 @@ class AgentConfigBase(Base):
     locations: list[str] = []
     event_types: list[str] = []
     sources: list[str] = []
-    honorary_participants: list[str] = []
+    honorary_participants: dict[str, list[str]] = {}
     custom_queries: list[str] = []
 
 


### PR DESCRIPTION
fix(agent-config): update agent_conf field type in schema

- Updated schema AgentConfigBase: honorary_participants now uses `dict[str, list[str]]` instead of previous type `list`
- Example new value:
  {
    "business": ["John Doe", "Jane Smith"],
    "GR": ["Alex Brown"]
  }
