### PR TITLE
Feat/group honorary participants

### DIFF
--- a/server/server/api/email.py
+++ b/server/server/api/email.py
@@ -30,7 +30,6 @@ async def send_registration_email(
     Returns:
         Статус отправки
     """
-    print("hohlbi")
     events = await events_service.list(
         models.Event.id.in_(data.event_ids),
         auto_expunge=True,
@@ -68,7 +67,6 @@ async def send_registration_email(
 
     try:
         await mailer_grpc_client.send_registration_notification(req)
-
     except grpc.aio.AioRpcError as e:
         raise litestar.exceptions.HTTPException(
             status_code=502,

--- a/server/server/schemas.py
+++ b/server/server/schemas.py
@@ -108,7 +108,7 @@ class AgentConfigBase(Base):
     locations: list[str] = []
     event_types: list[str] = []
     sources: list[str] = []
-    honorary_participants: list[str] = []
+    honorary_participants: dict[str, list[str]] = {}
     custom_queries: list[str] = []
 
 


### PR DESCRIPTION
fix(agent-config): update agent_conf field type in schema

Updated schema AgentConfigBase: honorary_participants now uses dict[str, list[str]] instead of previous type list
Example new value:
{
    "business": ["John Doe", "Jane Smith"],
    "GR": ["Alex Brown"]
}